### PR TITLE
Add Plotting Frequency Settings Option

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/settings/StatisticsSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/StatisticsSettingsFragment.java
@@ -1,17 +1,36 @@
 package de.dennisguse.opentracks.settings;
+import de.dennisguse.opentracks.R;
+import de.dennisguse.opentracks.ui.aggregatedStatistics.dailyStats.Frequency;
 
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
+import androidx.preference.ListPreference;
 import androidx.preference.PreferenceFragmentCompat;
 
-import de.dennisguse.opentracks.R;
+import java.util.List;
 
 public class StatisticsSettingsFragment extends PreferenceFragmentCompat {
 
     @Override
     public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey) {
         addPreferencesFromResource(R.xml.settings_statistics);
+        ListPreference freqPreference = findPreference(getString(R.string.plotting_frequency_key));
+        String[] plottingFreqEntries = new String[Frequency.values().length]; //List of frequencies
+        String[] plottingFreqValues = new String[Frequency.values().length]; //List of frequency IDs
+
+        List<Frequency> allFreqValues = List.of(Frequency.values());
+        int iterFreq = 0;
+        for (Frequency freqValue: allFreqValues) {
+            plottingFreqEntries[iterFreq] = Integer.toString(freqValue.getValue());
+            plottingFreqValues[iterFreq] = Integer.toString(freqValue.getId());
+            iterFreq++;
+        }
+        freqPreference.setEntries(plottingFreqEntries);
+        freqPreference.setEntryValues(plottingFreqValues);
+
+
+
     }
 
     @Override

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -422,5 +422,6 @@
 
     <string name="prefs_last_version_key" translatable="false">lastVersionKey</string>
     <string name="settings_stats_display_key" translatable="false">settingsStatsDisplay</string>
+    <string name="plotting_frequency_key" translatable="false">plottingFreqKey</string>
 
 </resources>

--- a/src/main/res/xml/settings_statistics.xml
+++ b/src/main/res/xml/settings_statistics.xml
@@ -6,4 +6,9 @@
     <PreferenceCategory app:title="@string/settings_daily_stats_title">
 
     </PreferenceCategory>
+    <ListPreference android:key="@string/plotting_frequency_key"
+        app:useSimpleSummaryProvider="true"
+        app:title="Plotting Aggregation Frequency"
+        android:defaultValue="0"/>
+
 </PreferenceScreen>


### PR DESCRIPTION
**Describe the pull request**
The pull request adds the option to choose the frequency of data points at which the moving average should be calculated.

**Link to the the issue**
The commit contributes to the following issue: https://github.com/rilling/OpenTracks-Winter-2024-COMP-354/issues/124