### PR TITLE
Tristan Sprint3 - Metric 

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/settings/StatisticsSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/StatisticsSettingsFragment.java
@@ -3,15 +3,32 @@ package de.dennisguse.opentracks.settings;
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
+import androidx.preference.ListPreference;
 import androidx.preference.PreferenceFragmentCompat;
 
 import de.dennisguse.opentracks.R;
+import de.dennisguse.opentracks.ui.aggregatedStatistics.dailyStats.Metric;
 
 public class StatisticsSettingsFragment extends PreferenceFragmentCompat {
 
     @Override
     public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey) {
         addPreferencesFromResource(R.xml.settings_statistics);
+
+        ListPreference metricPreference = findPreference(getString(R.string.plotting_metric_key));
+
+        String[] metricEntries = new String[Metric.values().length]; //Metric display names
+        String[] metricEntryValues = new String[Metric.values().length]; //Metric IDs
+
+        int iterMetric = 0;
+        for(Metric metric: Metric.values()) {
+            metricEntries[iterMetric] = metric.toString();
+            metricEntryValues[iterMetric] = Integer.toString(metric.getId());
+            iterMetric++;
+        }
+
+        metricPreference.setEntries(metricEntries);
+        metricPreference.setEntryValues(metricEntryValues);
     }
 
     @Override

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -422,5 +422,6 @@
 
     <string name="prefs_last_version_key" translatable="false">lastVersionKey</string>
     <string name="settings_stats_display_key" translatable="false">settingsStatsDisplay</string>
+    <string name="plotting_metric_key" translatable="false"/>
 
 </resources>

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -422,6 +422,6 @@
 
     <string name="prefs_last_version_key" translatable="false">lastVersionKey</string>
     <string name="settings_stats_display_key" translatable="false">settingsStatsDisplay</string>
-    <string name="plotting_metric_key" translatable="false"/>
-
+    <string name="plotting_metric_key" translatable="false">plottingMetricKey</string>
+    
 </resources>

--- a/src/main/res/xml/settings_statistics.xml
+++ b/src/main/res/xml/settings_statistics.xml
@@ -4,6 +4,9 @@
     android:title="@string/settings_stats_display_title">
 
     <PreferenceCategory app:title="@string/settings_daily_stats_title">
-
+        <ListPreference android:key="@string/plotting_metric_key"
+            app:title="Plotting Aggregation Metric"
+            android:defaultValue="0"
+            app:useSimpleSummaryProvider="true"/>
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Issue https://github.com/rilling/OpenTracks-Winter-2024-COMP-354/issues/123
Added the option to choose which default Metric to display, found in the Statistics Display in Settings.
